### PR TITLE
use @sveltejs adapter instead of custom adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "0.0.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
-				"@chientrm/adapter-cloudflare": "^3.0.2",
 				"@envelop/graphql-jit": "^8.0.1",
 				"@fontsource/fira-mono": "^4.5.10",
 				"@graphql-yoga/plugin-response-cache": "^3.2.1",
@@ -17,7 +16,7 @@
 				"@neoconfetti/svelte": "^1.0.0",
 				"@neondatabase/serverless": "^0.6.0",
 				"@playwright/test": "^1.37.1",
-				"@sveltejs/adapter-cloudflare": "^3.0.1",
+				"@sveltejs/adapter-cloudflare": "^4.1.0",
 				"@sveltejs/kit": "^2.1.2",
 				"@sveltejs/vite-plugin-svelte": "^3.0.1",
 				"@types/bcryptjs": "^2.4.6",
@@ -114,20 +113,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@chientrm/adapter-cloudflare": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@chientrm/adapter-cloudflare/-/adapter-cloudflare-3.0.2.tgz",
-			"integrity": "sha512-DUdXdx9Lj6qHLtGt57R2+QqBN/9qrM9kbLYIOuBrDO2gANO0wtKw46fpE3dPfcJCkGQhV1UYyvi3CAWPOhAGEg==",
-			"dev": true,
-			"dependencies": {
-				"@cloudflare/workers-types": "^4.20231121.0",
-				"esbuild": "^0.19.9",
-				"worktop": "0.8.0-next.15"
-			},
-			"peerDependencies": {
-				"@sveltejs/kit": "^2.0.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -1828,17 +1813,39 @@
 			"dev": true
 		},
 		"node_modules/@sveltejs/adapter-cloudflare": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-3.0.1.tgz",
-			"integrity": "sha512-yhncGexWlDE3DAd6N/wsuel7BFwgBGWkvTG8iMAEaE/dHSEEUEUXOFK4IMKtPZWFuIkXmyfLxOSD8A8Kzv7ppg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-cloudflare/-/adapter-cloudflare-4.1.0.tgz",
+			"integrity": "sha512-AQQdZAZpcFDcBiMEmxbMYhn4yKZYoPZrKUrYpVejjbO+9obIGIuj/jWjVzAEkHqZMZuoRRqPbq+Zq+AWRm4x1Q==",
 			"dev": true,
 			"dependencies": {
 				"@cloudflare/workers-types": "^4.20231121.0",
-				"esbuild": "^0.19.9",
-				"worktop": "0.8.0-next.15"
+				"esbuild": "^0.19.11",
+				"worktop": "0.8.0-next.18"
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-cloudflare/node_modules/regexparam": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
+			"integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@sveltejs/adapter-cloudflare/node_modules/worktop": {
+			"version": "0.8.0-next.18",
+			"resolved": "https://registry.npmjs.org/worktop/-/worktop-0.8.0-next.18.tgz",
+			"integrity": "sha512-+TvsA6VAVoMC3XDKR5MoC/qlLqDixEfOBysDEKnPIPou/NvoPWCAuXHXMsswwlvmEuvX56lQjvELLyLuzTKvRw==",
+			"dev": true,
+			"dependencies": {
+				"mrmime": "^2.0.0",
+				"regexparam": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
@@ -6388,15 +6395,6 @@
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
 			"dev": true
 		},
-		"node_modules/regexparam": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
-			"integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/resolve": {
 			"version": "1.22.8",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -8109,28 +8107,6 @@
 				"@cloudflare/workerd-linux-64": "1.20231218.0",
 				"@cloudflare/workerd-linux-arm64": "1.20231218.0",
 				"@cloudflare/workerd-windows-64": "1.20231218.0"
-			}
-		},
-		"node_modules/worktop": {
-			"version": "0.8.0-next.15",
-			"resolved": "https://registry.npmjs.org/worktop/-/worktop-0.8.0-next.15.tgz",
-			"integrity": "sha512-0ycNO52P6nVwsjr1y20zuf0nqJatAb8L7MODBfQIxbxndHV5O4s50oZZMHWhJG1RLpHwbK0Epq8aaQK4E2GlgQ==",
-			"dev": true,
-			"dependencies": {
-				"mrmime": "^1.0.0",
-				"regexparam": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/worktop/node_modules/mrmime": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
-			"integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/wrangler": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 		"test:unit": "vitest"
 	},
 	"devDependencies": {
-		"@chientrm/adapter-cloudflare": "^3.0.2",
 		"@envelop/graphql-jit": "^8.0.1",
 		"@fontsource/fira-mono": "^4.5.10",
 		"@graphql-yoga/plugin-response-cache": "^3.2.1",
@@ -35,7 +34,7 @@
 		"@neoconfetti/svelte": "^1.0.0",
 		"@neondatabase/serverless": "^0.6.0",
 		"@playwright/test": "^1.37.1",
-		"@sveltejs/adapter-cloudflare": "^3.0.1",
+		"@sveltejs/adapter-cloudflare": "^4.1.0",
 		"@sveltejs/kit": "^2.1.2",
 		"@sveltejs/vite-plugin-svelte": "^3.0.1",
 		"@types/bcryptjs": "^2.4.6",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
 // import adapter from '@sveltejs/adapter-cloudflare';
-import adapter from '@chientrm/adapter-cloudflare'; //this adepter can support for node
+import adapter from '@sveltejs/adapter-cloudflare'; //this adepter can support for node
 
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { mdsvex } from 'mdsvex';


### PR DESCRIPTION
In latest update [4.1.0](https://github.com/sveltejs/kit/blob/main/packages/adapter-cloudflare/CHANGELOG.md),

`@sveltejs/adapter-cloudflare` has fixed the `nodejs_compat` flag so that no need to use my custom `@chientrm/adapter-cloudflare` adapter anymore.